### PR TITLE
Fix noImplicitAny error

### DIFF
--- a/firebase.d.ts
+++ b/firebase.d.ts
@@ -11,7 +11,7 @@ declare namespace firebase {
             TIMESTAMP,
         }
 
-        export function enableLogging(enable: boolean);
+        export function enableLogging(enable: boolean): void;
     }
 
 


### PR DESCRIPTION
This allows this type definition to be used with the `--noImplicitAny` flag in Typescript.
